### PR TITLE
clear localstorage by key: horoscope

### DIFF
--- a/source/horoscope/js/history.js
+++ b/source/horoscope/js/history.js
@@ -58,7 +58,7 @@ function init() {
     if (clear != null) {
     //clear horoscopes when clear button is clicked
     clear.addEventListener('click', function () {
-        localStorage.clear();
+        localStorage.removeItem('horoscopes');
         horoscopes = [];
         horoscopesJSON.clear();
         savedList.innerHTML = "";


### PR DESCRIPTION
This just changes one line of code in history.js. Instead of clearing the entirety of localStorage, we are now just clearing localStorage at the key 'horoscopes' when we click the clear all button on the saved horoscopes page.